### PR TITLE
Fix canvas size to avoid aliasing

### DIFF
--- a/jsdecoder/gameboy_printer_js_decoder.html
+++ b/jsdecoder/gameboy_printer_js_decoder.html
@@ -1219,7 +1219,7 @@ FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
 
 <br>
 <input id="submit_button" type="button" value="Click to Update Gameboy Tile"><br/><br/>
-<canvas id="demo_canvas" width="500" height="500" style="image-rendering: pixelated">
+<canvas id="demo_canvas" width="480" height="432" style="image-rendering: pixelated">
   Your browser doesn't support the HTML5 canvas :(
 </canvas>
 </div>


### PR DESCRIPTION
Changes the canvas size to 480x432 pixels (multiple of 160x144) to avoid aliasing effects.