### PR TITLE
jsdecoder: split image using lower margin in print command

### DIFF
--- a/gbp_decoder/jsdecoderV2/gbp_gameboyprinter2bpp.js
+++ b/gbp_decoder/jsdecoderV2/gbp_gameboyprinter2bpp.js
@@ -131,6 +131,10 @@ function render_gbp(rawBytes)
                     {
                         return 'INIT'
                     }
+                    else if (command.command === 'PRNT' && command.margin_lower === 3)
+                    {
+                        return 'PRNTCUT'
+                    }
                 } catch (error)
                 {
                     throw new Error('Error while trying to parse JSON data block in line ' + (1 + line_number));
@@ -141,11 +145,22 @@ function render_gbp(rawBytes)
         .filter(Boolean)
         .forEach(function (tile_element)
         {
-            if ((tile_element === 'INIT'))
+
+            if ((tile_element === 'INIT' && currentImage))
+            {
+                //
+            }
+            else if ((tile_element === 'INIT' && !currentImage))
             {
                 currentImage = [];
+            }
+            else if ((tile_element === 'PRNTCUT'))
+            {
                 images.push(currentImage);
-            } else {
+                currentImage = [];
+            }
+            else
+            {
                 try
                 {
                     currentImage.push(tile_element);


### PR DESCRIPTION
Check the lower margin on the print command and identify tile element as print and cut. Only tested this with Game Boy Camera but it seems to work for all prints.