### PR TITLE
Use Serial.println on last byte in parse mode

### DIFF
--- a/gbp_emulator/gbp_emulator_v2/gbp_emulator_v2.ino
+++ b/gbp_emulator/gbp_emulator_v2/gbp_emulator_v2.ino
@@ -25,8 +25,8 @@
  *
  */
 
-#define GBP_RAW_PACKET_MODE false // output raw data packets for parsing and decompressing later
-#define GBP_USE_DECOMPRESSOR_MODE false // embedded decompressor requires fast hardware (SAMD21, SAMD51, ESP8266, ESP32)
+#define GBP_OUTPUT_RAW_PACKETS false // by default, packets are parsed. if enabled, output will change to raw data packets for parsing and decompressing later
+#define GBP_USE_PARSE_DECOMPRESSOR false // embedded decompressor can be enabled for use with parse mode but it requires fast hardware (SAMD21, SAMD51, ESP8266, ESP32)
 
 #include <stdint.h> // uint8_t
 #include <stddef.h> // size_t
@@ -34,11 +34,11 @@
 #include "gameboy_printer_protocol.h"
 #include "gbp_serial_io.h"
 
-#if GBP_RAW_PACKET_MODE
+#if GBP_OUTPUT_RAW_PACKETS
   #define GBP_FEATURE_PACKET_CAPTURE_MODE
 #else
   #define GBP_FEATURE_PARSE_PACKET_MODE
-  #if GBP_USE_DECOMPRESSOR_MODE
+  #if GBP_USE_PARSE_DECOMPRESSOR
     #define GBP_FEATURE_PARSE_PACKET_USE_DECOMPRESSOR
   #endif
 #endif


### PR DESCRIPTION
Printing line returns separately after the last byte of a tile in parse mode seems to cause timeouts for compressed data. This change switches to use Serial.println when printing the last byte instead.

Tested working here on camera, super mario deluxe, pokemon tcg using ESP8266, needs testing on Arduino boards.

![Game Boy Photo 20200822 - 141818](https://user-images.githubusercontent.com/9136454/90966121-94695080-e483-11ea-8290-7159f80d653f.png)
